### PR TITLE
Algo Tweak to enable xmr-stak

### DIFF
--- a/multihashing.cc
+++ b/multihashing.cc
@@ -537,6 +537,11 @@ DECLARE_FUNC(cryptonightsoftshell) {
     }
 
     uint32_t scratchpad = CN_SOFT_SHELL_MEMORY + (static_cast<uint32_t>(offset) * CN_SOFT_SHELL_PAD_MULTIPLIER);
+	scratchpad = (static_cast<uint64_t>(scratchpad / 64)) * 64;
+    if ((scratchpad / 64) % 2 != 0)
+    {
+        scratchpad -= 64;
+    }
     uint32_t iterations = CN_SOFT_SHELL_ITER + (static_cast<uint32_t>(offset) * CN_SOFT_SHELL_ITER_MULTIPLIER);
 
     char * input = Buffer::Data(target);

--- a/multihashing.cc
+++ b/multihashing.cc
@@ -537,11 +537,7 @@ DECLARE_FUNC(cryptonightsoftshell) {
     }
 
     uint32_t scratchpad = CN_SOFT_SHELL_MEMORY + (static_cast<uint32_t>(offset) * CN_SOFT_SHELL_PAD_MULTIPLIER);
-	scratchpad = (static_cast<uint64_t>(scratchpad / 64)) * 64;
-    if ((scratchpad / 64) % 2 != 0)
-    {
-        scratchpad -= 64;
-    }
+	scratchpad = (static_cast<uint64_t>(scratchpad / 128)) * 128;
     uint32_t iterations = CN_SOFT_SHELL_ITER + (static_cast<uint32_t>(offset) * CN_SOFT_SHELL_ITER_MULTIPLIER);
 
     char * input = Buffer::Data(target);


### PR DESCRIPTION
xmr-stak alignment requires that scratchpad is divisible by 64 and division by 64 results in even number